### PR TITLE
geom_alt props

### DIFF
--- a/data/421/202/165/421202165.geojson
+++ b/data/421/202/165/421202165.geojson
@@ -706,6 +706,9 @@
     ],
     "wof:country":"SY",
     "wof:created":1459010107,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb4f33152cad8f4ef0a4c32f58681958",
     "wof:hierarchy":[
         {
@@ -717,7 +720,7 @@
         }
     ],
     "wof:id":421202165,
-    "wof:lastmodified":1566652203,
+    "wof:lastmodified":1582344848,
     "wof:name":"Damascus",
     "wof:parent_id":85678403,
     "wof:placetype":"locality",

--- a/data/856/324/13/85632413.geojson
+++ b/data/856/324/13/85632413.geojson
@@ -1017,7 +1017,6 @@
     "src:geom_alt":[
         "quattroshapes",
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1095,7 +1094,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1582344836,
+    "wof:lastmodified":1583223717,
     "wof:name":"Syria",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/13/85632413.geojson
+++ b/data/856/324/13/85632413.geojson
@@ -1015,9 +1015,10 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "quattroshapes",
         "naturalearth",
-        "meso",
-        "quattroshapes"
+        "naturalearth",
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1072,6 +1073,12 @@
     },
     "wof:country":"SY",
     "wof:country_alpha3":"SYR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"196c1c8770ecef92afab0fe536fd2614",
     "wof:hierarchy":[
         {
@@ -1088,7 +1095,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651481,
+    "wof:lastmodified":1582344836,
     "wof:name":"Syria",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/783/45/85678345.geojson
+++ b/data/856/783/45/85678345.geojson
@@ -410,6 +410,9 @@
         "wd:id":"Q233236"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0646ae020c05fc2bb17297135f695e2",
     "wof:hierarchy":[
         {
@@ -427,7 +430,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651484,
+    "wof:lastmodified":1582344837,
     "wof:name":"Lattakia",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/49/85678349.geojson
+++ b/data/856/783/49/85678349.geojson
@@ -391,6 +391,9 @@
         "wd:id":"Q232382"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0186c4ac34a71ac61c4f765d0ab40797",
     "wof:hierarchy":[
         {
@@ -408,7 +411,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651488,
+    "wof:lastmodified":1582344838,
     "wof:name":"Tartus",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/55/85678355.geojson
+++ b/data/856/783/55/85678355.geojson
@@ -309,6 +309,9 @@
         "wd:id":"Q235563"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57906299f05f23be1e30b577a2086703",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651487,
+    "wof:lastmodified":1582344838,
     "wof:name":"Ar Raqqah",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/59/85678359.geojson
+++ b/data/856/783/59/85678359.geojson
@@ -323,6 +323,9 @@
         "wd:id":"Q214064"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55c93e2acb9bdc0662e6e147d6691189",
     "wof:hierarchy":[
         {
@@ -340,7 +343,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651483,
+    "wof:lastmodified":1582344837,
     "wof:name":"Aleppo",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/63/85678363.geojson
+++ b/data/856/783/63/85678363.geojson
@@ -343,6 +343,9 @@
         "wk:page":"Hama Governorate"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c7d717c7cc169b254aeee58408584c3",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651487,
+    "wof:lastmodified":1582344838,
     "wof:name":"Hamah",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/67/85678367.geojson
+++ b/data/856/783/67/85678367.geojson
@@ -346,6 +346,9 @@
         "wk:page":"Homs Governorate"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62dc45ac2c5d7e142016cac3bff26498",
     "wof:hierarchy":[
         {
@@ -363,7 +366,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651484,
+    "wof:lastmodified":1582344837,
     "wof:name":"Homs (Hims)",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/73/85678373.geojson
+++ b/data/856/783/73/85678373.geojson
@@ -402,6 +402,9 @@
         "wd:id":"Q233218"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d5502f366d91ea9cde0477ebbbc6595",
     "wof:hierarchy":[
         {
@@ -419,7 +422,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651485,
+    "wof:lastmodified":1582344837,
     "wof:name":"Idlib",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/77/85678377.geojson
+++ b/data/856/783/77/85678377.geojson
@@ -342,6 +342,9 @@
         "wk:page":"Al-Hasakah Governorate"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02980d4353bf81dc454bc9857d874c3e",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651487,
+    "wof:lastmodified":1582344838,
     "wof:name":"Hasaka (Al Haksa)",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/81/85678381.geojson
+++ b/data/856/783/81/85678381.geojson
@@ -334,6 +334,9 @@
         "wd:id":"Q232387"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9f844122fff7ff7d89174223ed27d57",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651485,
+    "wof:lastmodified":1582344837,
     "wof:name":"Days Az Zawr",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/85/85678385.geojson
+++ b/data/856/783/85/85678385.geojson
@@ -331,6 +331,9 @@
         "wk:page":"As-Suwayda Governorate"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a93d0efcd15a77c8c5ca149bd7faa880",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651488,
+    "wof:lastmodified":1582344838,
     "wof:name":"As Suwayda'",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/91/85678391.geojson
+++ b/data/856/783/91/85678391.geojson
@@ -158,6 +158,9 @@
         "unlc:id":"SY-RD"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5df42f7f3f02484a57d41233f3a7e667",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651486,
+    "wof:lastmodified":1582344838,
     "wof:name":"Rif Dimashq",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/95/85678395.geojson
+++ b/data/856/783/95/85678395.geojson
@@ -322,6 +322,9 @@
         "wd:id":"Q219690"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b47b1989ca72117c139d74f8190420b",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651482,
+    "wof:lastmodified":1582344837,
     "wof:name":"Quneitra",
     "wof:parent_id":85632221,
     "wof:placetype":"region",

--- a/data/856/783/99/85678399.geojson
+++ b/data/856/783/99/85678399.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Daraa Governorate"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2ebd2e4c32dba2bedad8435d2d9b172",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651486,
+    "wof:lastmodified":1582344838,
     "wof:name":"Dar`a",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/784/03/85678403.geojson
+++ b/data/856/784/03/85678403.geojson
@@ -695,6 +695,9 @@
         421202165
     ],
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb4f33152cad8f4ef0a4c32f58681958",
     "wof:hierarchy":[
         {
@@ -712,7 +715,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566651488,
+    "wof:lastmodified":1582344839,
     "wof:name":"Damascus",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/859/030/33/85903033.geojson
+++ b/data/859/030/33/85903033.geojson
@@ -102,6 +102,10 @@
         "wk:page":"Qanawat, Damascus"
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb3d9dce7724c65494eb3334bd988db6",
     "wof:hierarchy":[
         {
@@ -117,7 +121,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566651480,
+    "wof:lastmodified":1582344835,
     "wof:name":"Al Qanaw\u00e5t",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/35/85903035.geojson
+++ b/data/859/030/35/85903035.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1119560
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3236dc747252f0ec93dfa60a6ef938dc",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566651480,
+    "wof:lastmodified":1582344835,
     "wof:name":"\u2018Am\u0101rah al Juww\u0101n\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/37/85903037.geojson
+++ b/data/859/030/37/85903037.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1119557
     },
     "wof:country":"SY",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff7a51fdce93411f7a649adbe81a7d30",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566651480,
+    "wof:lastmodified":1582344836,
     "wof:name":"Mayd\u00e5n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.