### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/177/699/421177699.geojson
+++ b/data/421/177/699/421177699.geojson
@@ -69,7 +69,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423083,
     "wof:name":"Akkar",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/421/177/699/421177699.geojson
+++ b/data/421/177/699/421177699.geojson
@@ -16,6 +16,12 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":18.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0643\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Akkar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -63,8 +69,8 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1529541195,
-    "wof:name":"\u0639\u0643\u0627\u0631",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Akkar",
     "wof:parent_id":85632413,
     "wof:placetype":"region",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/182/331/421182331.geojson
+++ b/data/421/182/331/421182331.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":34.900738,
     "geom:longitude":35.8889,
     "iso:country":"SY",
+    "label:eng_x_preferred_longname":[
+        "Tartus Governate"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "governate"
+    ],
     "lbl:bbox":"35.8689,34.880738,35.9089,34.920738",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,7 +27,10 @@
         "\u0645\u064f\u062d\u0627\u0641\u0638\u0629 \u0637\u0631\u0637\u0648\u0633"
     ],
     "name:eng_x_preferred":[
-        "Tartus Governorate"
+        "Tartus"
+    ],
+    "name:eng_x_variant":[
+        "Tartus Governate"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -66,8 +75,8 @@
         }
     ],
     "wof:id":421182331,
-    "wof:lastmodified":1601068400,
-    "wof:name":"Tartus Governorate",
+    "wof:lastmodified":1601339397,
+    "wof:name":"Tartus",
     "wof:parent_id":1108779153,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/182/331/421182331.geojson
+++ b/data/421/182/331/421182331.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":34.900738,
     "geom:longitude":35.8889,
     "iso:country":"SY",
-    "label:eng_x_preferred_longname":[
-        "Tartus Governate"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "governate"
-    ],
     "lbl:bbox":"35.8689,34.880738,35.9089,34.920738",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -54,8 +48,8 @@
     "wof:belongsto":[
         102191569,
         85632413,
-        85678349,
-        1108779153
+        1108779153,
+        85678349
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +69,7 @@
         }
     ],
     "wof:id":421182331,
-    "wof:lastmodified":1601339397,
+    "wof:lastmodified":1601423056,
     "wof:name":"Tartus",
     "wof:parent_id":1108779153,
     "wof:placetype":"locality",

--- a/data/421/182/331/421182331.geojson
+++ b/data/421/182/331/421182331.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u064f\u062d\u0627\u0641\u0638\u0629 \u0637\u0631\u0637\u0648\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Tartus Governorate"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182331,
-    "wof:lastmodified":1566652210,
-    "wof:name":"\u0645\u064f\u062d\u0627\u0641\u0638\u0629 \u0637\u0631\u0637\u0648\u0633",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Tartus Governorate",
     "wof:parent_id":1108779153,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/188/347/421188347.geojson
+++ b/data/421/188/347/421188347.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0634\u064a\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Rashaya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"SY",
     "wof:created":1459009542,
-    "wof:geomhash":"db9555c52db01a288fba7a2120ac531f",
+    "wof:geomhash":"b6916a344d35a10e5bec92e80473dd62",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421188347,
-    "wof:lastmodified":1481738377,
-    "wof:name":"\u0631\u0627\u0634\u064a\u0627",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Rashaya",
     "wof:parent_id":85678391,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/188/347/421188347.geojson
+++ b/data/421/188/347/421188347.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421188347,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Rashaya",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/421/190/427/421190427.geojson
+++ b/data/421/190/427/421190427.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u064f\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0644\u0627\u0630\u0642\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Latakia Governorate"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190427,
-    "wof:lastmodified":1566652207,
-    "wof:name":"\u0645\u064f\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0644\u0627\u0630\u0642\u064a\u0629",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Latakia Governorate",
     "wof:parent_id":1108779125,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/190/427/421190427.geojson
+++ b/data/421/190/427/421190427.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":35.52538,
     "geom:longitude":35.786075,
     "iso:country":"SY",
-    "label:eng_x_preferred_longname":[
-        "Latakia Governate"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "governate"
-    ],
     "lbl:bbox":"35.766075,35.50538,35.806075,35.54538",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -54,8 +48,8 @@
     "wof:belongsto":[
         102191569,
         85632413,
-        85678345,
-        1108779125
+        1108779125,
+        85678345
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +69,7 @@
         }
     ],
     "wof:id":421190427,
-    "wof:lastmodified":1601339397,
+    "wof:lastmodified":1601423020,
     "wof:name":"Latakia",
     "wof:parent_id":1108779125,
     "wof:placetype":"locality",

--- a/data/421/190/427/421190427.geojson
+++ b/data/421/190/427/421190427.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":35.52538,
     "geom:longitude":35.786075,
     "iso:country":"SY",
+    "label:eng_x_preferred_longname":[
+        "Latakia Governate"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "governate"
+    ],
     "lbl:bbox":"35.766075,35.50538,35.806075,35.54538",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,7 +27,10 @@
         "\u0645\u064f\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0644\u0627\u0630\u0642\u064a\u0629"
     ],
     "name:eng_x_preferred":[
-        "Latakia Governorate"
+        "Latakia"
+    ],
+    "name:eng_x_variant":[
+        "Latakia Governate"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -66,8 +75,8 @@
         }
     ],
     "wof:id":421190427,
-    "wof:lastmodified":1601068400,
-    "wof:name":"Latakia Governorate",
+    "wof:lastmodified":1601339397,
+    "wof:name":"Latakia",
     "wof:parent_id":1108779125,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/190/431/421190431.geojson
+++ b/data/421/190/431/421190431.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632413,
-        85678391,
-        1108779095
+        1108779095,
+        85678391
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190431,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Nabk",
     "wof:parent_id":1108779095,
     "wof:placetype":"locality",

--- a/data/421/190/431/421190431.geojson
+++ b/data/421/190/431/421190431.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0628\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Al Nabk"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190431,
-    "wof:lastmodified":1566652206,
-    "wof:name":"\u0627\u0644\u0646\u0628\u0643",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Nabk",
     "wof:parent_id":1108779095,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/190/449/421190449.geojson
+++ b/data/421/190/449/421190449.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0639\u0631\u0627\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Murada"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190449,
-    "wof:lastmodified":1566652205,
-    "wof:name":"\u0645\u0639\u0631\u0627\u062f\u0629",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Murada",
     "wof:parent_id":1108779175,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-sy",

--- a/data/421/190/449/421190449.geojson
+++ b/data/421/190/449/421190449.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632413,
-        85678363,
-        1108779175
+        1108779175,
+        85678363
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190449,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Murada",
     "wof:parent_id":1108779175,
     "wof:placetype":"locality",

--- a/data/421/202/299/421202299.geojson
+++ b/data/421/202/299/421202299.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421202299,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423083,
     "wof:name":"Akkar",
     "wof:parent_id":85678367,
     "wof:placetype":"county",

--- a/data/421/202/299/421202299.geojson
+++ b/data/421/202/299/421202299.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0643\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Akkar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"SY",
     "wof:created":1459010112,
-    "wof:geomhash":"10d184ba32b0f90b5cbf226fa3ce2c5d",
+    "wof:geomhash":"c0e0771febcced1f7aef45e327e26815",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421202299,
-    "wof:lastmodified":1481738378,
-    "wof:name":"\u0639\u0643\u0627\u0631",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Akkar",
     "wof:parent_id":85678367,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-sy",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.