### PR TITLE
sy concordances, placetype local, and more

### DIFF
--- a/data/110/877/907/3/1108779073.geojson
+++ b/data/110/877/907/3/1108779073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.312634,
-    "geom:area_square_m":3104159008.713973,
+    "geom:area_square_m":3104159008.713819,
     "geom:bbox":"38.02657,36.150258,38.70912,36.924123",
     "geom:latitude":36.583673,
     "geom:longitude":38.390338,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HL.AA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737473,
-    "wof:geomhash":"5b0c44bb7e0d2a5a8802470131f6eefa",
+    "wof:geomhash":"63583996e034234e5ad777f2782a4f6d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779073,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Ain Al Arab",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/907/7/1108779077.geojson
+++ b/data/110/877/907/7/1108779077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153968,
-    "geom:area_square_m":1603379698.909444,
+    "geom:area_square_m":1603379698.909251,
     "geom:bbox":"35.760505,32.359903,36.543908,32.881713",
     "geom:latitude":32.628854,
     "geom:longitude":36.20464,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.DR.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737474,
-    "wof:geomhash":"a99f5f6e9aca2a920428ca06c1c76f67",
+    "wof:geomhash":"b36c341a157893c40b9380cc7cbdddd1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779077,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886504,
     "wof:name":"Dar'a",
     "wof:parent_id":85678399,
     "wof:placetype":"county",

--- a/data/110/877/907/9/1108779079.geojson
+++ b/data/110/877/907/9/1108779079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.918691,
-    "geom:area_square_m":19802006350.3619,
+    "geom:area_square_m":19802006350.36174,
     "geom:bbox":"36.338716,32.666206,39.11448,33.988556",
     "geom:latitude":33.419945,
     "geom:longitude":37.684714,
@@ -115,9 +115,10 @@
         "hasc:id":"SY.RD.DM",
         "wd:id":"Q986780"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737475,
-    "wof:geomhash":"60bb3b55b5aad968bde43e8e9d468eea",
+    "wof:geomhash":"1f651c7a67c7edb1fcb14be086c12b16",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108779079,
-    "wof:lastmodified":1690867857,
+    "wof:lastmodified":1695886293,
     "wof:name":"Duma",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/908/1/1108779081.geojson
+++ b/data/110/877/908/1/1108779081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129157,
-    "geom:area_square_m":1337772051.63129,
+    "geom:area_square_m":1337772051.631025,
     "geom:bbox":"35.586898,32.876297,35.996325,33.354869",
     "geom:latitude":33.106988,
     "geom:longitude":35.804905,
@@ -184,9 +184,10 @@
     "wof:concordances":{
         "hasc:id":"SY.QU.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737476,
-    "wof:geomhash":"01f98f00b26cd40b1e84244688caf852",
+    "wof:geomhash":"fedbb9ac89eb71da533388c9a267dc71",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1108779081,
-    "wof:lastmodified":1636500548,
+    "wof:lastmodified":1695886759,
     "wof:name":"Quneitra",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/877/908/3/1108779083.geojson
+++ b/data/110/877/908/3/1108779083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.394355,
-    "geom:area_square_m":3909797232.065277,
+    "geom:area_square_m":3909797232.06556,
     "geom:bbox":"39.506216,36.203488,40.777966,37.114607",
     "geom:latitude":36.697156,
     "geom:longitude":40.141688,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HA.RN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737477,
-    "wof:geomhash":"b5e1a0872deb598b325bd8ce0f7bd3d1",
+    "wof:geomhash":"bdbfdc08b886107245998c349c71bd7a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779083,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886507,
     "wof:name":"Ras Al Ain",
     "wof:parent_id":85678377,
     "wof:placetype":"county",

--- a/data/110/877/908/5/1108779085.geojson
+++ b/data/110/877/908/5/1108779085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.977675,
-    "geom:area_square_m":30360227310.8367,
+    "geom:area_square_m":30360227310.836182,
     "geom:bbox":"37.604242,33.541572,40.232775,35.400053",
     "geom:latitude":34.453052,
     "geom:longitude":38.861983,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HI.TD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737478,
-    "wof:geomhash":"0ab447a379a1a8e3e2f4419779002fe9",
+    "wof:geomhash":"135138a88b624988d4b19f0b0ebc9715",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779085,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886507,
     "wof:name":"Tadmor",
     "wof:parent_id":85678367,
     "wof:placetype":"county",

--- a/data/110/877/908/7/1108779087.geojson
+++ b/data/110/877/908/7/1108779087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064522,
-    "geom:area_square_m":663750597.304768,
+    "geom:area_square_m":663750597.30472,
     "geom:bbox":"35.93559,33.549807,36.284203,33.85316",
     "geom:latitude":33.700428,
     "geom:longitude":36.121852,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.ZB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737479,
-    "wof:geomhash":"c269aa7684ed72474f1c610ba09a2f73",
+    "wof:geomhash":"afd1fbc2db2d607d150a4ecec5fd947c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779087,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Az-Zabdani",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/908/9/1108779089.geojson
+++ b/data/110/877/908/9/1108779089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189374,
-    "geom:area_square_m":1880782600.696378,
+    "geom:area_square_m":1880782600.696462,
     "geom:bbox":"36.542538,36.29808,37.047663,36.828922",
     "geom:latitude":36.56401,
     "geom:longitude":36.790137,
@@ -139,9 +139,10 @@
         "hasc:id":"SY.HL.AF",
         "wd:id":"Q4120569"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737480,
-    "wof:geomhash":"c36079b7cc89cedc31e8d3b5e53fe8ac",
+    "wof:geomhash":"48c4e85577cb7c3f522671d046d66599",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108779089,
-    "wof:lastmodified":1690867858,
+    "wof:lastmodified":1695886293,
     "wof:name":"Afrin",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/909/1/1108779091.geojson
+++ b/data/110/877/909/1/1108779091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05936,
-    "geom:area_square_m":604581101.302056,
+    "geom:area_square_m":604581101.301874,
     "geom:bbox":"36.333805,34.348364,36.78506,34.667127",
     "geom:latitude":34.544667,
     "geom:longitude":36.564503,
@@ -121,9 +121,10 @@
         "hasc:id":"SY.HI.QS",
         "wd:id":"Q4115829"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737482,
-    "wof:geomhash":"e2598edf7d23743c3ab78fcd2dea2aa4",
+    "wof:geomhash":"52c1f7f6eafeb65329d0208ad6b80685",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108779091,
-    "wof:lastmodified":1690867857,
+    "wof:lastmodified":1695886507,
     "wof:name":"Al-Qusayr",
     "wof:parent_id":85678367,
     "wof:placetype":"county",

--- a/data/110/877/909/5/1108779095.geojson
+++ b/data/110/877/909/5/1108779095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11041,
-    "geom:area_square_m":1130909913.856653,
+    "geom:area_square_m":1130909913.856624,
     "geom:bbox":"36.49955,33.845511,37.001247,34.240671",
     "geom:latitude":34.069109,
     "geom:longitude":36.754094,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737483,
-    "wof:geomhash":"b80dcf65fc0faf5f61e1b5909d3e150e",
+    "wof:geomhash":"517bd4346bb3e6623dc3e85b6077d392",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108779095,
-    "wof:lastmodified":1636500548,
+    "wof:lastmodified":1695886759,
     "wof:name":"An Nabk",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/909/7/1108779097.geojson
+++ b/data/110/877/909/7/1108779097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060156,
-    "geom:area_square_m":603565663.658359,
+    "geom:area_square_m":603565663.658505,
     "geom:bbox":"36.391386,35.634724,36.719989,35.906683",
     "geom:latitude":35.764839,
     "geom:longitude":36.546013,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"SY.ID.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737484,
-    "wof:geomhash":"357afd8c7fe588dbcc3e8d63cbd09065",
+    "wof:geomhash":"1b6ab600281c65e9d5c72ff2fd63f692",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108779097,
-    "wof:lastmodified":1587164334,
+    "wof:lastmodified":1695886293,
     "wof:name":"Ariha",
     "wof:parent_id":85678373,
     "wof:placetype":"county",

--- a/data/110/877/909/9/1108779099.geojson
+++ b/data/110/877/909/9/1108779099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11026,
-    "geom:area_square_m":1110431718.731449,
+    "geom:area_square_m":1110431718.731495,
     "geom:bbox":"36.206387,35.190265,36.522713,35.761661",
     "geom:latitude":35.465186,
     "geom:longitude":36.333901,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HM.SQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737485,
-    "wof:geomhash":"a48109eed090cbac83ad52b030db4061",
+    "wof:geomhash":"2332db04ca92e1afe09551899072005b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779099,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886503,
     "wof:name":"As-Suqaylabiyah",
     "wof:parent_id":85678363,
     "wof:placetype":"county",

--- a/data/110/877/910/1/1108779101.geojson
+++ b/data/110/877/910/1/1108779101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.613409,
-    "geom:area_square_m":6198897943.66785,
+    "geom:area_square_m":6198897943.667781,
     "geom:bbox":"36.873684,34.863027,38.45084,35.481591",
     "geom:latitude":35.187704,
     "geom:longitude":37.656178,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HM.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737486,
-    "wof:geomhash":"a2ae7b99e6a82efa7fc819e42955113e",
+    "wof:geomhash":"5c637f3aa0bf35563ceb92deac9073a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779101,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886503,
     "wof:name":"As-Salamiyeh",
     "wof:parent_id":85678363,
     "wof:placetype":"county",

--- a/data/110/877/910/3/1108779103.geojson
+++ b/data/110/877/910/3/1108779103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.546032,
-    "geom:area_square_m":5479563348.088531,
+    "geom:area_square_m":5479563348.088587,
     "geom:bbox":"38.058715,35.324625,39.163551,36.282896",
     "geom:latitude":35.749538,
     "geom:longitude":38.539735,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RA.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737487,
-    "wof:geomhash":"536c66cf2bbf1bd875a9bb31b7245f4f",
+    "wof:geomhash":"5c1bbfb37db46fa2520b17a297d6f567",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779103,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886503,
     "wof:name":"Ath-Thawrah",
     "wof:parent_id":85678355,
     "wof:placetype":"county",

--- a/data/110/877/910/5/1108779105.geojson
+++ b/data/110/877/910/5/1108779105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054727,
-    "geom:area_square_m":562952731.002982,
+    "geom:area_square_m":562952731.002972,
     "geom:bbox":"36.225922,33.557617,36.514939,33.844965",
     "geom:latitude":33.705815,
     "geom:longitude":36.361508,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.TL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737488,
-    "wof:geomhash":"efaecda5ccd45294a9a146243d49f948",
+    "wof:geomhash":"08c3ad9ecb131c27d76b20c9d432a0cd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779105,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886504,
     "wof:name":"At Tall",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/910/7/1108779107.geojson
+++ b/data/110/877/910/7/1108779107.geojson
@@ -564,6 +564,7 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.RD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421202165
     ],
@@ -579,7 +580,7 @@
         }
     ],
     "wof:id":1108779107,
-    "wof:lastmodified":1694498105,
+    "wof:lastmodified":1695886759,
     "wof:name":"Damascus",
     "wof:parent_id":85678403,
     "wof:placetype":"county",

--- a/data/110/877/910/9/1108779109.geojson
+++ b/data/110/877/910/9/1108779109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009902,
-    "geom:area_square_m":102160338.164322,
+    "geom:area_square_m":102160338.164326,
     "geom:bbox":"36.158817,33.384461,36.310987,33.52423",
     "geom:latitude":33.449363,
     "geom:longitude":36.23259,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737490,
-    "wof:geomhash":"37be8b102ea7999408828034c7ec1ea2",
+    "wof:geomhash":"a01a4800419a725fafc2f7dff739ed63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108779109,
-    "wof:lastmodified":1587164334,
+    "wof:lastmodified":1695886293,
     "wof:name":"Darayya",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/911/3/1108779113.geojson
+++ b/data/110/877/911/3/1108779113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.283873,
-    "geom:area_square_m":2847054068.934527,
+    "geom:area_square_m":2847054068.934406,
     "geom:bbox":"37.204574,35.43116,37.937161,36.196726",
     "geom:latitude":35.796633,
     "geom:longitude":37.552689,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HL.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737491,
-    "wof:geomhash":"6a38bc5ac88fcc8366261c8788eb5f9e",
+    "wof:geomhash":"623ed8204e8b11d85dcae98811bf3b68",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108779113,
-    "wof:lastmodified":1587164334,
+    "wof:lastmodified":1695886293,
     "wof:name":"As-Safira",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/911/5/1108779115.geojson
+++ b/data/110/877/911/5/1108779115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.251926,
-    "geom:area_square_m":2544413569.937759,
+    "geom:area_square_m":2544413569.937666,
     "geom:bbox":"36.425291,34.895309,37.500176,35.560296",
     "geom:latitude":35.234214,
     "geom:longitude":36.896088,
@@ -124,9 +124,10 @@
         "hasc:id":"SY.HM.HM",
         "wd:id":"Q2856152"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737492,
-    "wof:geomhash":"f8e9340530950936b6620195286761f7",
+    "wof:geomhash":"932b4bad36b0ba47eda173b81ea37baf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108779115,
-    "wof:lastmodified":1690867859,
+    "wof:lastmodified":1695886293,
     "wof:name":"Hama",
     "wof:parent_id":85678363,
     "wof:placetype":"county",

--- a/data/110/877/911/7/1108779117.geojson
+++ b/data/110/877/911/7/1108779117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129052,
-    "geom:area_square_m":1282771640.936883,
+    "geom:area_square_m":1282771640.936776,
     "geom:bbox":"36.915499,36.272009,37.437449,36.677322",
     "geom:latitude":36.499272,
     "geom:longitude":37.179106,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HL.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737493,
-    "wof:geomhash":"aa64a25a01d9041d1b25f16a37f10172",
+    "wof:geomhash":"c6fc8e1df2deeded0a090e3a49c3aedf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779117,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886503,
     "wof:name":"A'zaz",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/911/9/1108779119.geojson
+++ b/data/110/877/911/9/1108779119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064726,
-    "geom:area_square_m":641702896.959199,
+    "geom:area_square_m":641702896.959186,
     "geom:bbox":"37.640119,36.53032,38.088816,36.832092",
     "geom:latitude":36.699751,
     "geom:longitude":37.86037,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HL.JR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737494,
-    "wof:geomhash":"7353e38822e0931d693a90000cf330e3",
+    "wof:geomhash":"d2996fd8f6be49311deb8cca062ae2fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779119,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Jarablus",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/912/1/1108779121.geojson
+++ b/data/110/877/912/1/1108779121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.306096,
-    "geom:area_square_m":3062063861.282738,
+    "geom:area_square_m":3062063861.283036,
     "geom:bbox":"36.713152,35.508744,37.434196,36.374744",
     "geom:latitude":35.999807,
     "geom:longitude":37.113713,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HL.JS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737495,
-    "wof:geomhash":"97418813a565577a67e8415456bff564",
+    "wof:geomhash":"5fd2dbf72b0dea5cae321a3e9e1d20fe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779121,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Jebel Saman",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/912/3/1108779123.geojson
+++ b/data/110/877/912/3/1108779123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.201461,
-    "geom:area_square_m":2026631184.89206,
+    "geom:area_square_m":2026631184.892089,
     "geom:bbox":"36.392656,35.379093,37.201694,35.754453",
     "geom:latitude":35.556066,
     "geom:longitude":36.794925,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.ID.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737497,
-    "wof:geomhash":"f2b6cc93993030b6491d4aaa6b92cb56",
+    "wof:geomhash":"2948634202fe78175e8b6f97b19a75a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779123,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Al Ma'ra",
     "wof:parent_id":85678373,
     "wof:placetype":"county",

--- a/data/110/877/912/5/1108779125.geojson
+++ b/data/110/877/912/5/1108779125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100226,
-    "geom:area_square_m":1006242521.152728,
+    "geom:area_square_m":1006242521.152702,
     "geom:bbox":"35.713585,35.454898,36.148976,35.940862",
     "geom:latitude":35.714631,
     "geom:longitude":35.928407,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SY.LA.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737498,
-    "wof:geomhash":"2276d1390726f53b75c5bbfe3449e855",
+    "wof:geomhash":"532b822bb969db7cc4cccbc46eb1d026",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108779125,
-    "wof:lastmodified":1636500548,
+    "wof:lastmodified":1695886759,
     "wof:name":"Lattakia",
     "wof:parent_id":85678345,
     "wof:placetype":"county",

--- a/data/110/877/912/7/1108779127.geojson
+++ b/data/110/877/912/7/1108779127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035765,
-    "geom:area_square_m":360246139.357856,
+    "geom:area_square_m":360246139.357816,
     "geom:bbox":"35.91627,35.357239,36.230588,35.527268",
     "geom:latitude":35.453632,
     "geom:longitude":36.092824,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.LA.QR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737499,
-    "wof:geomhash":"93f79d5715cbfc811b0f0fc2f0e9912f",
+    "wof:geomhash":"3552171793e05cbc1ee69e21a4b2fbf8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779127,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Al-Qardaha",
     "wof:parent_id":85678345,
     "wof:placetype":"county",

--- a/data/110/877/913/1/1108779131.geojson
+++ b/data/110/877/913/1/1108779131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050485,
-    "geom:area_square_m":509343467.262178,
+    "geom:area_square_m":509343467.262291,
     "geom:bbox":"35.876602,35.221607,36.237355,35.466354",
     "geom:latitude":35.32095,
     "geom:longitude":36.060674,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.LA.JB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737500,
-    "wof:geomhash":"8af10c965e78d11d0a4b02c6ff665983",
+    "wof:geomhash":"3ada1af6144836c50d2e160d9448a199",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779131,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886504,
     "wof:name":"Jablah",
     "wof:parent_id":85678345,
     "wof:placetype":"county",

--- a/data/110/877/913/3/1108779133.geojson
+++ b/data/110/877/913/3/1108779133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059699,
-    "geom:area_square_m":603617457.247933,
+    "geom:area_square_m":603617457.247927,
     "geom:bbox":"35.882751,35.028713,36.271811,35.270236",
     "geom:latitude":35.14529,
     "geom:longitude":36.083946,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.TA.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737501,
-    "wof:geomhash":"6f9fb8e9eea68f987e42d9d0aa18d731",
+    "wof:geomhash":"bfd4ecbedc25879611422f33bd7e7a00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779133,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886505,
     "wof:name":"Banyas",
     "wof:parent_id":85678349,
     "wof:placetype":"county",

--- a/data/110/877/913/5/1108779135.geojson
+++ b/data/110/877/913/5/1108779135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079677,
-    "geom:area_square_m":806465633.84394,
+    "geom:area_square_m":806465633.843931,
     "geom:bbox":"36.148702,34.85641,36.535027,35.246754",
     "geom:latitude":35.059168,
     "geom:longitude":36.368827,
@@ -121,9 +121,10 @@
         "hasc:id":"SY.HM.MF",
         "wd:id":"Q2586299"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737502,
-    "wof:geomhash":"f22fd31eb4dce3fdcd55b887c01b9c03",
+    "wof:geomhash":"84387746eba73a266e351e2e3aeb0272",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108779135,
-    "wof:lastmodified":1690867858,
+    "wof:lastmodified":1695886293,
     "wof:name":"Masyaf",
     "wof:parent_id":85678363,
     "wof:placetype":"county",

--- a/data/110/877/913/7/1108779137.geojson
+++ b/data/110/877/913/7/1108779137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129073,
-    "geom:area_square_m":1336933558.291355,
+    "geom:area_square_m":1336933558.291399,
     "geom:bbox":"35.946856,32.911457,36.571298,33.296396",
     "geom:latitude":33.105248,
     "geom:longitude":36.275134,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.DR.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737503,
-    "wof:geomhash":"e415c52d9979e29cfe04b62b0b35345d",
+    "wof:geomhash":"b01a72f668032f3d3e5e2a0c183a9510",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779137,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886504,
     "wof:name":"As-Sanamayn",
     "wof:parent_id":85678399,
     "wof:placetype":"county",

--- a/data/110/877/913/9/1108779139.geojson
+++ b/data/110/877/913/9/1108779139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096172,
-    "geom:area_square_m":993122423.592767,
+    "geom:area_square_m":993122423.592774,
     "geom:bbox":"35.81557,33.153497,36.208556,33.573002",
     "geom:latitude":33.370346,
     "geom:longitude":36.031071,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.QT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737504,
-    "wof:geomhash":"e5fc396b1d1c7925410b75a6f7d19fe5",
+    "wof:geomhash":"6b70afcedc0a2b44f3eca51a46a208a7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108779139,
-    "wof:lastmodified":1587164334,
+    "wof:lastmodified":1695886293,
     "wof:name":"Qatana",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/914/1/1108779141.geojson
+++ b/data/110/877/914/1/1108779141.geojson
@@ -106,6 +106,7 @@
         "hasc:id":"SY.RD.RD",
         "wd:id":"Q4118382"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737505,
     "wof:geomhash":"113b8496f61c8325f241e7790cbb8cbc",
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108779141,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886442,
     "wof:name":"Rural Damascus",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/914/3/1108779143.geojson
+++ b/data/110/877/914/3/1108779143.geojson
@@ -106,6 +106,7 @@
         "hasc:id":"SY.RD.RD",
         "wd:id":"Q4118382"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737506,
     "wof:geomhash":"fd3fda4ddde815eb3a88ba564861b1e0",
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108779143,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886442,
     "wof:name":"Rural Damascus",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/914/5/1108779145.geojson
+++ b/data/110/877/914/5/1108779145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018269,
-    "geom:area_square_m":185206807.219968,
+    "geom:area_square_m":185206807.219972,
     "geom:bbox":"36.0066,34.870381,36.268725,34.98646",
     "geom:latitude":34.926704,
     "geom:longitude":36.14205,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.TA.DK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737508,
-    "wof:geomhash":"3cdb6f92a289eee7f17d7021aa26a361",
+    "wof:geomhash":"f2cc121bfff306905e8f7b3c9178d33b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779145,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886505,
     "wof:name":"Dreikish",
     "wof:parent_id":85678349,
     "wof:placetype":"county",

--- a/data/110/877/914/9/1108779149.geojson
+++ b/data/110/877/914/9/1108779149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02116,
-    "geom:area_square_m":214263268.450153,
+    "geom:area_square_m":214263268.450137,
     "geom:bbox":"35.956243,34.951129,36.252858,35.094168",
     "geom:latitude":35.025161,
     "geom:longitude":36.09008,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"SY.TA.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737509,
-    "wof:geomhash":"5d9abefd5468db6efbc520ef0478e4cf",
+    "wof:geomhash":"2bb6a2e9fb0dd3ce9d4c3988b056f33e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108779149,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886507,
     "wof:name":"Sheikh Badr",
     "wof:parent_id":85678349,
     "wof:placetype":"county",

--- a/data/110/877/915/1/1108779151.geojson
+++ b/data/110/877/915/1/1108779151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.391061,
-    "geom:area_square_m":3965209779.120905,
+    "geom:area_square_m":3965209779.120853,
     "geom:bbox":"39.700543,34.583773,41.131764,35.266421",
     "geom:latitude":34.913782,
     "geom:longitude":40.437497,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.DY.MY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737510,
-    "wof:geomhash":"86999bc6e6dfda7a776b31056a33f078",
+    "wof:geomhash":"6d9a201b39d7b6a9bb9e8ca66b488cdb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779151,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Al Mayadin",
     "wof:parent_id":85678381,
     "wof:placetype":"county",

--- a/data/110/877/915/3/1108779153.geojson
+++ b/data/110/877/915/3/1108779153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056075,
-    "geom:area_square_m":569135444.18652,
+    "geom:area_square_m":569135444.186406,
     "geom:bbox":"35.863834,34.62741,36.127983,35.070318",
     "geom:latitude":34.833135,
     "geom:longitude":35.983442,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737510,
-    "wof:geomhash":"d496a527ed6da649f354b0028306de9c",
+    "wof:geomhash":"f0ec3a8b5cca15af597396e803e270b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779153,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886507,
     "wof:name":"Tartous",
     "wof:parent_id":85678349,
     "wof:placetype":"county",

--- a/data/110/877/915/5/1108779155.geojson
+++ b/data/110/877/915/5/1108779155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055761,
-    "geom:area_square_m":572013783.827123,
+    "geom:area_square_m":572013783.826992,
     "geom:bbox":"36.27521,33.824492,36.690639,34.05432",
     "geom:latitude":33.941722,
     "geom:longitude":36.487516,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.YB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737512,
-    "wof:geomhash":"266181885c37a3303a74605378199fb8",
+    "wof:geomhash":"0d84dd0f5e5430f2e12087da7bafae4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108779155,
-    "wof:lastmodified":1587164334,
+    "wof:lastmodified":1695886294,
     "wof:name":"Yabroud",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/915/7/1108779157.geojson
+++ b/data/110/877/915/7/1108779157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.423123,
-    "geom:area_square_m":14334094497.300203,
+    "geom:area_square_m":14334094497.300535,
     "geom:bbox":"39.246999,34.788891,41.278556,36.329087",
     "geom:latitude":35.454433,
     "geom:longitude":40.169789,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.DY.DY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737513,
-    "wof:geomhash":"5d362294b73042975e957592206d9771",
+    "wof:geomhash":"af418e39ca956e30ed93fa307528845e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779157,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886505,
     "wof:name":"Deir-ez-Zor",
     "wof:parent_id":85678381,
     "wof:placetype":"county",

--- a/data/110/877/915/9/1108779159.geojson
+++ b/data/110/877/915/9/1108779159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076289,
-    "geom:area_square_m":761693850.839015,
+    "geom:area_square_m":761693850.839051,
     "geom:bbox":"36.365296,35.911821,36.839347,36.339299",
     "geom:latitude":36.152082,
     "geom:longitude":36.574093,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.ID.HR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737514,
-    "wof:geomhash":"78f17b916272e19f4a63982f4d4ec27f",
+    "wof:geomhash":"7e7150db81e7e0d2dc56e6526f60d7fe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779159,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886505,
     "wof:name":"Harim",
     "wof:parent_id":85678373,
     "wof:placetype":"county",

--- a/data/110/877/916/1/1108779161.geojson
+++ b/data/110/877/916/1/1108779161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204049,
-    "geom:area_square_m":2031579399.510694,
+    "geom:area_square_m":2031579399.510642,
     "geom:bbox":"37.309368,36.069206,37.865098,36.737034",
     "geom:latitude":36.37111,
     "geom:longitude":37.559824,
@@ -142,9 +142,10 @@
         "hasc:id":"SY.HL.BB",
         "wd:id":"Q4118360"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737515,
-    "wof:geomhash":"75d1ce1d635f043e36ce983e59627990",
+    "wof:geomhash":"ee8057058d12965576427a69b69c10e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108779161,
-    "wof:lastmodified":1690867859,
+    "wof:lastmodified":1695886294,
     "wof:name":"Al Bab",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/916/3/1108779163.geojson
+++ b/data/110/877/916/3/1108779163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056639,
-    "geom:area_square_m":569277045.736964,
+    "geom:area_square_m":569277045.736932,
     "geom:bbox":"35.906414,35.484187,36.255169,35.788763",
     "geom:latitude":35.62544,
     "geom:longitude":36.104666,
@@ -124,9 +124,10 @@
         "hasc:id":"SY.LA.HF",
         "wd:id":"Q2278356"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737516,
-    "wof:geomhash":"188fafee5ff5cb3096137533199896b1",
+    "wof:geomhash":"47980af3383f1f772270705b9bd16496",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108779163,
-    "wof:lastmodified":1690867859,
+    "wof:lastmodified":1695886294,
     "wof:name":"Al-Haffa",
     "wof:parent_id":85678345,
     "wof:placetype":"county",

--- a/data/110/877/916/7/1108779167.geojson
+++ b/data/110/877/916/7/1108779167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155625,
-    "geom:area_square_m":1598860252.975396,
+    "geom:area_square_m":1598860252.975404,
     "geom:bbox":"36.466291,33.613528,37.288926,34.021626",
     "geom:latitude":33.812387,
     "geom:longitude":36.824379,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RD.QF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737517,
-    "wof:geomhash":"f69d5d57ff6d1a27834f639057047fd9",
+    "wof:geomhash":"adf018e3a3b3c6f2ea5aa1e3cc7f9145",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779167,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886504,
     "wof:name":"Al Qutayfah",
     "wof:parent_id":85678391,
     "wof:placetype":"county",

--- a/data/110/877/916/9/1108779169.geojson
+++ b/data/110/877/916/9/1108779169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.731995,
-    "geom:area_square_m":7330002958.14205,
+    "geom:area_square_m":7330002958.141891,
     "geom:bbox":"38.412574,35.278492,39.747477,36.368912",
     "geom:latitude":35.919763,
     "geom:longitude":39.168325,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RA.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737519,
-    "wof:geomhash":"821c8c1be3b097a743cee883f9ad1bc1",
+    "wof:geomhash":"8c2144a36f02972497126982e60a0a2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779169,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886507,
     "wof:name":"Ar-Raqqa",
     "wof:parent_id":85678355,
     "wof:placetype":"county",

--- a/data/110/877/917/1/1108779171.geojson
+++ b/data/110/877/917/1/1108779171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029072,
-    "geom:area_square_m":294834661.775435,
+    "geom:area_square_m":294834661.775453,
     "geom:bbox":"36.589355,34.817743,36.967813,34.978085",
     "geom:latitude":34.898973,
     "geom:longitude":36.776153,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HI.RS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737520,
-    "wof:geomhash":"6491093e859cb75c9134ae122f7accf5",
+    "wof:geomhash":"68e7ddb20cb812597d410ccb05d5d004",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779171,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886508,
     "wof:name":"Ar-Rastan",
     "wof:parent_id":85678367,
     "wof:placetype":"county",

--- a/data/110/877/917/3/1108779173.geojson
+++ b/data/110/877/917/3/1108779173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143712,
-    "geom:area_square_m":1439633176.665778,
+    "geom:area_square_m":1439633176.665649,
     "geom:bbox":"36.427926,35.608827,37.141459,36.149216",
     "geom:latitude":35.890625,
     "geom:longitude":36.79113,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.ID.ID"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737521,
-    "wof:geomhash":"ac5e5da94e8c4358be17d6dd5c38849c",
+    "wof:geomhash":"6e667ffd18fbe033acba8ff40ff91c72",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779173,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886505,
     "wof:name":"Idleb",
     "wof:parent_id":85678373,
     "wof:placetype":"county",

--- a/data/110/877/917/5/1108779175.geojson
+++ b/data/110/877/917/5/1108779175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043133,
-    "geom:area_square_m":435306314.046302,
+    "geom:area_square_m":435306314.046219,
     "geom:bbox":"36.416577,35.161708,36.676111,35.419067",
     "geom:latitude":35.295232,
     "geom:longitude":36.557424,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HM.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737522,
-    "wof:geomhash":"d5761368181d31ef39203d71e17b5e08",
+    "wof:geomhash":"4d444a4a41d1053a0040d6d2761fdc32",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779175,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Muhradah",
     "wof:parent_id":85678363,
     "wof:placetype":"county",

--- a/data/110/877/917/7/1108779177.geojson
+++ b/data/110/877/917/7/1108779177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092019,
-    "geom:area_square_m":955623703.290152,
+    "geom:area_square_m":955623703.290142,
     "geom:bbox":"35.912403,32.698838,36.41239,33.034448",
     "geom:latitude":32.874424,
     "geom:longitude":36.180821,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.DR.IZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737523,
-    "wof:geomhash":"475b5e51b28a45ef45e7b61f8499d46d",
+    "wof:geomhash":"ffbae2c78c3cd04914ec68eb93c2f95a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779177,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886505,
     "wof:name":"Izra'",
     "wof:parent_id":85678399,
     "wof:placetype":"county",

--- a/data/110/877/917/9/1108779179.geojson
+++ b/data/110/877/917/9/1108779179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17261,
-    "geom:area_square_m":1790315570.675755,
+    "geom:area_square_m":1790315570.675793,
     "geom:bbox":"36.372527,32.777444,37.205519,33.199064",
     "geom:latitude":32.985219,
     "geom:longitude":36.723288,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"SY.SU.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737524,
-    "wof:geomhash":"20cbb69df856186b2e68532dff007854",
+    "wof:geomhash":"4a40f211f65929b17d06dcd25cd1f1aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108779179,
-    "wof:lastmodified":1587164335,
+    "wof:lastmodified":1695886294,
     "wof:name":"Shahba",
     "wof:parent_id":85678385,
     "wof:placetype":"county",

--- a/data/110/877/918/1/1108779181.geojson
+++ b/data/110/877/918/1/1108779181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046249,
-    "geom:area_square_m":470055999.061658,
+    "geom:area_square_m":470055999.061656,
     "geom:bbox":"36.117396,34.62229,36.464719,34.865331",
     "geom:latitude":34.718992,
     "geom:longitude":36.291417,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HI.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737525,
-    "wof:geomhash":"c37fd4b89562400af68b4d38c9fd6dcc",
+    "wof:geomhash":"a48eda57632679d077fe14380bfee495",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779181,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886508,
     "wof:name":"Tall Kalakh",
     "wof:parent_id":85678367,
     "wof:placetype":"county",

--- a/data/110/877/918/5/1108779185.geojson
+++ b/data/110/877/918/5/1108779185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.625308,
-    "geom:area_square_m":6365958255.739399,
+    "geom:area_square_m":6365958255.73934,
     "geom:bbox":"39.800517,34.11187,41.227515,35.104246",
     "geom:latitude":34.581219,
     "geom:longitude":40.575707,
@@ -183,9 +183,10 @@
     "wof:concordances":{
         "hasc:id":"SY.DY.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737526,
-    "wof:geomhash":"1cf8e5a14211d8766593dedc74834a53",
+    "wof:geomhash":"1d1ff0beb51bee12bd3cf9afc5f14de5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":1108779185,
-    "wof:lastmodified":1636500548,
+    "wof:lastmodified":1695886759,
     "wof:name":"Abu Kamal",
     "wof:parent_id":85678381,
     "wof:placetype":"county",

--- a/data/110/877/918/7/1108779187.geojson
+++ b/data/110/877/918/7/1108779187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041632,
-    "geom:area_square_m":432560363.498973,
+    "geom:area_square_m":432560363.499131,
     "geom:bbox":"35.596207,32.677555,35.890506,32.965008",
     "geom:latitude":32.832191,
     "geom:longitude":35.735368,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SY.QU.FZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737527,
-    "wof:geomhash":"ea9cef13a38acbb1acf47aa9525d032e",
+    "wof:geomhash":"42a2bb3a4352caf8d29bda1928100a2d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108779187,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886505,
     "wof:name":"Al Fiq",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/877/918/9/1108779189.geojson
+++ b/data/110/877/918/9/1108779189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.259392,
-    "geom:area_square_m":12564436170.03229,
+    "geom:area_square_m":12564436170.032677,
     "geom:bbox":"40.007041,35.49767,41.382222,36.841351",
     "geom:latitude":36.21138,
     "geom:longitude":40.779246,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737528,
-    "wof:geomhash":"f7cdba7b0aa1970ab72045eb7c1cc1d8",
+    "wof:geomhash":"3271598916c194b567dbc295c832bd9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779189,
-    "wof:lastmodified":1627522805,
+    "wof:lastmodified":1695886506,
     "wof:name":"Al-Hasakeh",
     "wof:parent_id":85678377,
     "wof:placetype":"county",

--- a/data/110/877/919/1/1108779191.geojson
+++ b/data/110/877/919/1/1108779191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266406,
-    "geom:area_square_m":2632464626.435686,
+    "geom:area_square_m":2632464626.435822,
     "geom:bbox":"41.655823,36.599146,42.376309,37.320569",
     "geom:latitude":36.97995,
     "geom:longitude":41.989531,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HA.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737529,
-    "wof:geomhash":"934474d6e05edc82f55cc1fd38f49c38",
+    "wof:geomhash":"8cc4e2c81a3406f4e9378bb4de55af08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779191,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886504,
     "wof:name":"Al-Malikeyyeh",
     "wof:parent_id":85678377,
     "wof:placetype":"county",

--- a/data/110/877/919/3/1108779193.geojson
+++ b/data/110/877/919/3/1108779193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.409252,
-    "geom:area_square_m":4049060541.775272,
+    "geom:area_square_m":4049060541.775384,
     "geom:bbox":"40.721473,36.488094,41.833124,37.132197",
     "geom:latitude":36.857149,
     "geom:longitude":41.302819,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HA.QM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737530,
-    "wof:geomhash":"c4eca27a8e1b4a8b39d843cc64b85755",
+    "wof:geomhash":"c0fb7aa3b6c66996f85c0f3f8fe8631c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779193,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886506,
     "wof:name":"Quamishli",
     "wof:parent_id":85678377,
     "wof:placetype":"county",

--- a/data/110/877/919/5/1108779195.geojson
+++ b/data/110/877/919/5/1108779195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172679,
-    "geom:area_square_m":1800765662.291445,
+    "geom:area_square_m":1800765662.291409,
     "geom:bbox":"36.50328,32.311136,37.463461,32.679686",
     "geom:latitude":32.502702,
     "geom:longitude":36.88406,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"SY.SU.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737531,
-    "wof:geomhash":"8058fa175e0e85b431b8bdbe1c0874f3",
+    "wof:geomhash":"2b4df7936f6dbc5c804865074796da6e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108779195,
-    "wof:lastmodified":1587164335,
+    "wof:lastmodified":1695886294,
     "wof:name":"Salkhad",
     "wof:parent_id":85678385,
     "wof:placetype":"county",

--- a/data/110/877/919/7/1108779197.geojson
+++ b/data/110/877/919/7/1108779197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.488986,
-    "geom:area_square_m":4863955182.52663,
+    "geom:area_square_m":4863955182.526185,
     "geom:bbox":"38.581872,35.930067,39.90175,36.771535",
     "geom:latitude":36.443855,
     "geom:longitude":39.242716,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.RA.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737533,
-    "wof:geomhash":"2b7641484b6e198abec7dda0050f9785",
+    "wof:geomhash":"7dee284ba92dfc09db9f91d476b26c22",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779197,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886508,
     "wof:name":"Tell Abiad",
     "wof:parent_id":85678355,
     "wof:placetype":"county",

--- a/data/110/877/919/9/1108779199.geojson
+++ b/data/110/877/919/9/1108779199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268165,
-    "geom:area_square_m":2788673640.93958,
+    "geom:area_square_m":2788673640.939441,
     "geom:bbox":"36.359195,32.541221,37.456689,33.004731",
     "geom:latitude":32.754396,
     "geom:longitude":36.901945,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.SU.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737534,
-    "wof:geomhash":"fa3db1c06ffb37fe10503da707941c24",
+    "wof:geomhash":"cd6e5bb1a1f5c8bca4a2079f0f7723c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779199,
-    "wof:lastmodified":1627522807,
+    "wof:lastmodified":1695886508,
     "wof:name":"As-Sweida",
     "wof:parent_id":85678385,
     "wof:placetype":"county",

--- a/data/110/877/920/3/1108779203.geojson
+++ b/data/110/877/920/3/1108779203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297941,
-    "geom:area_square_m":3024803443.409239,
+    "geom:area_square_m":3024803443.409356,
     "geom:bbox":"36.966674,34.547921,37.917356,35.103665",
     "geom:latitude":34.810484,
     "geom:longitude":37.495494,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HI.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737535,
-    "wof:geomhash":"5d8d5640b688b162f2c2f5f336cf1155",
+    "wof:geomhash":"85244400c939e273fd06a0aec5ce8f3a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779203,
-    "wof:lastmodified":1627522804,
+    "wof:lastmodified":1695886504,
     "wof:name":"Al Makhrim",
     "wof:parent_id":85678367,
     "wof:placetype":"county",

--- a/data/110/877/920/5/1108779205.geojson
+++ b/data/110/877/920/5/1108779205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.517525,
-    "geom:area_square_m":5173451377.024714,
+    "geom:area_square_m":5173451377.024038,
     "geom:bbox":"37.696258,35.380464,38.310252,36.672855",
     "geom:latitude":36.054642,
     "geom:longitude":37.97876,
@@ -118,9 +118,10 @@
         "hasc:id":"SY.HL.MB",
         "wd:id":"Q4120577"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737537,
-    "wof:geomhash":"5e1deb360452c0402c339cd0d7078160",
+    "wof:geomhash":"6c2c277033950e1617879e03b396656e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108779205,
-    "wof:lastmodified":1690867859,
+    "wof:lastmodified":1695886507,
     "wof:name":"Menbij",
     "wof:parent_id":85678359,
     "wof:placetype":"county",

--- a/data/110/877/920/7/1108779207.geojson
+++ b/data/110/877/920/7/1108779207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063587,
-    "geom:area_square_m":637127085.683189,
+    "geom:area_square_m":637127085.683254,
     "geom:bbox":"36.147414,35.716629,36.463925,36.050587",
     "geom:latitude":35.872824,
     "geom:longitude":36.316134,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SY.ID.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737538,
-    "wof:geomhash":"6e24dcbc296fc8ade7a9b500237cedf2",
+    "wof:geomhash":"00c68c5fb0798093aa300beac8961c17",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108779207,
-    "wof:lastmodified":1627522806,
+    "wof:lastmodified":1695886507,
     "wof:name":"Jisr-Ash-Shugur",
     "wof:parent_id":85678373,
     "wof:placetype":"county",

--- a/data/110/877/920/9/1108779209.geojson
+++ b/data/110/877/920/9/1108779209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035592,
-    "geom:area_square_m":361295825.43963,
+    "geom:area_square_m":361295825.439658,
     "geom:bbox":"36.013519,34.690168,36.328158,34.933142",
     "geom:latitude":34.821703,
     "geom:longitude":36.152523,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"SY.TA.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737539,
-    "wof:geomhash":"90b91dde998915cf4f2f3c8e03f49fb6",
+    "wof:geomhash":"fad0b8597b31756bda69aa4f28b98611",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108779209,
-    "wof:lastmodified":1587164335,
+    "wof:lastmodified":1695886294,
     "wof:name":"Safita",
     "wof:parent_id":85678349,
     "wof:placetype":"county",

--- a/data/110/877/921/1/1108779211.geojson
+++ b/data/110/877/921/1/1108779211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.784824,
-    "geom:area_square_m":8007116198.5529,
+    "geom:area_square_m":8007116198.553064,
     "geom:bbox":"36.267147,33.929644,37.750187,34.954679",
     "geom:latitude":34.401335,
     "geom:longitude":37.113639,
@@ -303,9 +303,10 @@
     "wof:concordances":{
         "hasc:id":"SY.HI.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SY",
     "wof:created":1481737541,
-    "wof:geomhash":"3254e0cffa3d967d7cd9978701e0022e",
+    "wof:geomhash":"ec1801042fec0959d5aa9bdd33ac6725",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -315,7 +316,7 @@
         }
     ],
     "wof:id":1108779211,
-    "wof:lastmodified":1587164335,
+    "wof:lastmodified":1695886294,
     "wof:name":"Homs",
     "wof:parent_id":85678367,
     "wof:placetype":"county",

--- a/data/856/324/13/85632413.geojson
+++ b/data/856/324/13/85632413.geojson
@@ -1248,6 +1248,7 @@
         "hasc:id":"SY",
         "icao:code":"YK",
         "ioc:id":"SYR",
+        "iso:code":"SY",
         "itu:id":"SYR",
         "loc:id":"n80061798",
         "m49:code":"760",
@@ -1262,6 +1263,7 @@
         "wk:page":"Syria",
         "wmo:id":"SY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:country_alpha3":"SYR",
     "wof:geom_alt":[
@@ -1287,7 +1289,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1694639632,
+    "wof:lastmodified":1695881294,
     "wof:name":"Syria",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/783/45/85678345.geojson
+++ b/data/856/783/45/85678345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243115,
-    "geom:area_square_m":2445108775.848445,
+    "geom:area_square_m":2445109173.509845,
     "geom:bbox":"35.713585,35.221607,36.255169,35.940862",
     "geom:latitude":35.573705,
     "geom:longitude":36.021124,
@@ -434,15 +434,17 @@
         "gn:id":173578,
         "gp:id":2347070,
         "hasc:id":"SY.LA",
+        "iso:code":"SY-LA",
         "iso:id":"SY-LA",
         "qs_pg:id":1135343,
         "wd:id":"Q233236"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a24b000598b1f10145c844144dafbde",
+    "wof:geomhash":"49b8773d4e83ceaf22e2dafcd0af90ec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -459,7 +461,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867852,
+    "wof:lastmodified":1695884870,
     "wof:name":"Lattakia",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/49/85678349.geojson
+++ b/data/856/783/49/85678349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190795,
-    "geom:area_square_m":1933519190.489809,
+    "geom:area_square_m":1933518802.544207,
     "geom:bbox":"35.863834,34.62741,36.328158,35.270236",
     "geom:latitude":34.958931,
     "geom:longitude":36.073444,
@@ -401,16 +401,18 @@
         "gn:id":163342,
         "gp:id":2347082,
         "hasc:id":"SY.TA",
+        "iso:code":"SY-TA",
         "iso:id":"SY-TA",
         "qs_pg:id":215765,
         "unlc:id":"SY-TA",
         "wd:id":"Q232382"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"77bca8515b635e9a085b70c667e3092a",
+    "wof:geomhash":"04bc05df662d6fbc8724b4a31af0145a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -427,7 +429,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867854,
+    "wof:lastmodified":1695884537,
     "wof:name":"Tartus",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/55/85678355.geojson
+++ b/data/856/783/55/85678355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.767013,
-    "geom:area_square_m":17673521482.94471,
+    "geom:area_square_m":17673521488.757191,
     "geom:bbox":"38.058715,35.278492,39.90175,36.771535",
     "geom:latitude":36.012193,
     "geom:longitude":38.994668,
@@ -324,16 +324,18 @@
         "gn:id":172957,
         "gp:id":2347072,
         "hasc:id":"SY.RA",
+        "iso:code":"SY-RA",
         "iso:id":"SY-RA",
         "qs_pg:id":1135344,
         "unlc:id":"SY-RA",
         "wd:id":"Q235563"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c85254cbfe5fe2b8805fc6a05227a09",
+    "wof:geomhash":"59916b4d93195506ba3331bdde0d8d7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -350,7 +352,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867853,
+    "wof:lastmodified":1695884870,
     "wof:name":"Ar Raqqah",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/59/85678359.geojson
+++ b/data/856/783/59/85678359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.00733,
-    "geom:area_square_m":20023564397.716492,
+    "geom:area_square_m":20023564811.981739,
     "geom:bbox":"36.542538,35.380464,38.70912,36.924123",
     "geom:latitude":36.221799,
     "geom:longitude":37.640748,
@@ -345,15 +345,17 @@
         "gn:id":170062,
         "gp:id":2347077,
         "hasc:id":"SY.HL",
+        "iso:code":"SY-HL",
         "iso:id":"SY-HL",
         "qs_pg:id":900759,
         "wd:id":"Q214064"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52038e250af04493808ce6abd2b8482a",
+    "wof:geomhash":"9e5da337b60b068359db8bea7a0e084c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -370,7 +372,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867851,
+    "wof:lastmodified":1695884870,
     "wof:name":"Aleppo",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/63/85678363.geojson
+++ b/data/856/783/63/85678363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.098404,
-    "geom:area_square_m":11095515092.204372,
+    "geom:area_square_m":11095515180.227598,
     "geom:bbox":"36.148702,34.85641,38.45084,35.761661",
     "geom:latitude":35.221124,
     "geom:longitude":37.212584,
@@ -357,17 +357,19 @@
         "gn:id":170015,
         "gp:id":2347078,
         "hasc:id":"SY.HM",
+        "iso:code":"SY-HM",
         "iso:id":"SY-HM",
         "qs_pg:id":424021,
         "unlc:id":"SY-HM",
         "wd:id":"Q232355",
         "wk:page":"Hama Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0babbbad908ab96d7eba984ea13728fc",
+    "wof:geomhash":"db183323c028427023d7e122974c80b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -384,7 +386,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867853,
+    "wof:lastmodified":1695884536,
     "wof:name":"Hamah",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/67/85678367.geojson
+++ b/data/856/783/67/85678367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.195121,
-    "geom:area_square_m":42761619507.284271,
+    "geom:area_square_m":42761618714.937454,
     "geom:bbox":"36.117396,33.541572,40.232775,35.400053",
     "geom:latitude":34.476081,
     "geom:longitude":38.362551,
@@ -363,17 +363,19 @@
         "gn:id":169575,
         "gp:id":2347079,
         "hasc:id":"SY.HI",
+        "iso:code":"SY-HI",
         "iso:id":"SY-HI",
         "qs_pg:id":424034,
         "unlc:id":"SY-HI",
         "wd:id":"Q214094",
         "wk:page":"Homs Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"666534eacddb074de436500e21da02ff",
+    "wof:geomhash":"389cbb0c72cf51a98042f26d32e3c10d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -390,7 +392,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867851,
+    "wof:lastmodified":1695884537,
     "wof:name":"Homs (Hims)",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/73/85678373.geojson
+++ b/data/856/783/73/85678373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.545205,
-    "geom:area_square_m":5468651249.901663,
+    "geom:area_square_m":5468650967.170306,
     "geom:bbox":"36.147414,35.379093,37.201694,36.339299",
     "geom:latitude":35.78763,
     "geom:longitude":36.679719,
@@ -416,16 +416,18 @@
         "gn:id":169387,
         "gp:id":2347080,
         "hasc:id":"SY.ID",
+        "iso:code":"SY-ID",
         "iso:id":"SY-ID",
         "qs_pg:id":900760,
         "unlc:id":"SY-ID",
         "wd:id":"Q233218"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7120182a65d445d5e23cd6c64ee5e526",
+    "wof:geomhash":"33e008e9f9f58e29c4f15ce3835fd5a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -442,7 +444,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867852,
+    "wof:lastmodified":1695884870,
     "wof:name":"Idlib",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/77/85678377.geojson
+++ b/data/856/783/77/85678377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.329405,
-    "geom:area_square_m":23155758847.766174,
+    "geom:area_square_m":23155758570.308891,
     "geom:bbox":"39.506216,35.49767,42.376309,37.320569",
     "geom:latitude":36.494973,
     "geom:longitude":40.901714,
@@ -356,16 +356,18 @@
         "gn:id":173813,
         "gp:id":2347069,
         "hasc:id":"SY.HA",
+        "iso:code":"SY-HA",
         "iso:id":"SY-HA",
         "qs_pg:id":229385,
         "wd:id":"Q233914",
         "wk:page":"Al-Hasakah Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"44d891af42326887e56c78f512448166",
+    "wof:geomhash":"774cf03a00eb9a2567a090df4b5675ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -382,7 +384,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867854,
+    "wof:lastmodified":1695884537,
     "wof:name":"Hasaka (Al Haksa)",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/81/85678381.geojson
+++ b/data/856/783/81/85678381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.439493,
-    "geom:area_square_m":24665261672.795979,
+    "geom:area_square_m":24665262532.161453,
     "geom:bbox":"39.246999,34.11187,41.278556,36.329087",
     "geom:latitude":35.143936,
     "geom:longitude":40.316752,
@@ -346,16 +346,18 @@
         "gn:id":170792,
         "gp:id":2347075,
         "hasc:id":"SY.DY",
+        "iso:code":"SY-DY",
         "iso:id":"SY-DY",
         "qs_pg:id":1135345,
         "unlc:id":"SY-DY",
         "wd:id":"Q232387"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b9930f320cd45a2fa42fc60ad146664",
+    "wof:geomhash":"76dea984326153bc1ade51e28853148e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -372,7 +374,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867852,
+    "wof:lastmodified":1695884361,
     "wof:name":"Days Az Zawr",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/85/85678385.geojson
+++ b/data/856/783/85/85678385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.613454,
-    "geom:area_square_m":6379755121.211109,
+    "geom:area_square_m":6379754873.906967,
     "geom:bbox":"36.359195,32.311136,37.463461,33.199064",
     "geom:latitude":32.748495,
     "geom:longitude":36.846641,
@@ -352,17 +352,19 @@
         "gn:id":172410,
         "gp:id":2347073,
         "hasc:id":"SY.SU",
+        "iso:code":"SY-SU",
         "iso:id":"SY-SU",
         "qs_pg:id":211650,
         "unlc:id":"SY-SU",
         "wd:id":"Q236797",
         "wk:page":"As-Suwayda Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8dc9a5f4756a133992e48c100c8b695a",
+    "wof:geomhash":"0e8c70c1597e6d403901c1163f8c455a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -379,7 +381,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867854,
+    "wof:lastmodified":1695884870,
     "wof:name":"As Suwayda'",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/91/85678391.geojson
+++ b/data/856/783/91/85678391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.541537,
-    "geom:area_square_m":26207813534.512905,
+    "geom:area_square_m":26207813534.512585,
     "geom:bbox":"35.81557,32.6662056304,39.1144796185,34.2406706229",
     "geom:latitude":33.493541,
     "geom:longitude":37.388037,
@@ -153,15 +153,17 @@
         "gn:id":170652,
         "gp:id":2347076,
         "hasc:id":"SY.RD",
+        "iso:code":"SY-RD",
         "iso:id":"SY-RD",
         "qs_pg:id":1135346,
         "unlc:id":"SY-RD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5df42f7f3f02484a57d41233f3a7e667",
+    "wof:geomhash":"ed97a30b104b7908f9656ca0e42eb52b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1582344838,
+    "wof:lastmodified":1695884361,
     "wof:name":"Rif Dimashq",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/783/95/85678395.geojson
+++ b/data/856/783/95/85678395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170789,
-    "geom:area_square_m":1770332569.153505,
+    "geom:area_square_m":1770332415.129866,
     "geom:bbox":"35.586898,32.677555,35.996325,33.354869",
     "geom:latitude":33.040003,
     "geom:longitude":35.787954,
@@ -341,15 +341,17 @@
         "gn:id":173336,
         "gp:id":2347071,
         "hasc:id":"SY.QU",
+        "iso:code":"SY-QU",
         "iso:id":"SY-QU",
         "qs_pg:id":1135342,
         "wd:id":"Q219690"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da6f8d92f201dc64020d560160baf281",
+    "wof:geomhash":"ae21442f7dc3a3bec60f080ac9f04f7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -373,7 +375,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867851,
+    "wof:lastmodified":1695884870,
     "wof:name":"Quneitra",
     "wof:parent_id":85632221,
     "wof:placetype":"region",

--- a/data/856/783/99/85678399.geojson
+++ b/data/856/783/99/85678399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.375061,
-    "geom:area_square_m":3895937215.867302,
+    "geom:area_square_m":3895936960.646791,
     "geom:bbox":"35.760505,32.359903,36.571298,33.296396",
     "geom:latitude":32.85305,
     "geom:longitude":36.223056,
@@ -328,17 +328,19 @@
         "gn:id":170903,
         "gp:id":2347074,
         "hasc:id":"SY.DR",
+        "iso:code":"SY-DR",
         "iso:id":"SY-DR",
         "qs_pg:id":211651,
         "unlc:id":"SY-DR",
         "wd:id":"Q1689560",
         "wk:page":"Daraa Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"598105b233b5a8408fef05b57a1764f0",
+    "wof:geomhash":"78f79bcb73ee72ded7d5f9972d2538d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -355,7 +357,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690867853,
+    "wof:lastmodified":1695884871,
     "wof:name":"Dar`a",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/784/03/85678403.geojson
+++ b/data/856/784/03/85678403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010106,
-    "geom:area_square_m":104185772.849654,
+    "geom:area_square_m":104185730.376906,
     "geom:bbox":"36.197303,33.462504,36.35181,33.56536",
     "geom:latitude":33.515847,
     "geom:longitude":36.281452,
@@ -691,9 +691,11 @@
         "gn:id":167541,
         "gp:id":2347081,
         "hasc:id":"SY.DI",
+        "iso:code":"SY-DI",
         "iso:id":"SY-DI",
         "qs_pg:id":215764
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421202165
     ],
@@ -701,7 +703,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8b80cbcebc1eb4d758ddc10a8f634237",
+    "wof:geomhash":"b14aa6861a4690f510ff9612369f087f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -718,7 +720,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636500545,
+    "wof:lastmodified":1695884871,
     "wof:name":"Damascus",
     "wof:parent_id":85632413,
     "wof:placetype":"region",

--- a/data/856/813/85/85681385.geojson
+++ b/data/856/813/85/85681385.geojson
@@ -229,7 +229,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1694493125,
+    "wof:lastmodified":1695884281,
     "wof:name":"United Nations Disengagement Observer Force",
     "wof:parent_id":85632711,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.